### PR TITLE
fix(src): fix OOM when uploading many files

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -1,6 +1,6 @@
 {
     "projectFolder": ".",
-    "mainEntryPointFilePath": "<projectFolder>/build/index.d.ts",
+    "mainEntryPointFilePath": "<projectFolder>/build/src/index.d.ts",
     "bundledPackages": [],
     "compiler": {
       "tsconfigFilePath": "<projectFolder>/tsconfig.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numbersprotocol/estuary-upload",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@numbersprotocol/estuary-upload",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,10 @@ export default [
         banner: '#!/usr/bin/env node',
       },
     ],
-    plugins: [typescript({ tsconfig: "./tsconfig.json" })],
+    plugins: [
+      json(),
+      typescript({ tsconfig: "./tsconfig.json" })
+    ],
     external: [
       'fs', 'commander', 'ipfs-car/pack/blob', 'ipfs-car/blockstore/memory', 'axios',
     ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { Estuary } from './index.js';
 import fs from 'fs';
 import { Command, Option, OptionValues } from 'commander';
+import { version } from '../package.json';
 
 async function addDir(dirpath: string, options: OptionValues, command: Command) {
   const files = await fs.promises.readdir(dirpath);
@@ -18,6 +19,7 @@ async function addFiles(files: Array<string>, options: OptionValues, command: Co
 
 async function main() {
   const program = new Command('estuary-upload')
+    .version(version)
     .addOption(
       new Option('-k, --key <key>', 'Estuary API key')
         .env('ESTUARY_API_KEY')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "target": "es2017",
     "noImplicitAny": true,
@@ -14,5 +15,5 @@
       "*": ["node_modules/*", "src/types/*"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
Fix OOM issue when users try to upload many files at the same time. When adding files from path, save to temp file instead of memory to prevent from the memory be exhausted by a big file or by large amount files.

Add command -V to show the cli version.

Add default timeout 1 minute in Estuary class to replace original no timeout.