### PR TITLE
fix(index.ts): fix Estuary add ipfs request change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export class Estuary {
 
   async addFromCid(cid: string): Promise<string> {
     return this.client
-      .post('https://api.estuary.tech/content/add-ipfs', {root: cid})
+      .post('https://api.estuary.tech/content/add-ipfs', {cid: cid})
       .then((resp) => resp.data.pin.cid);
   }
 


### PR DESCRIPTION
The request body of Estuary API /content/add-ipfs is changed, the original format is {"root": <cid>} but now is {"cid": <cid>}. Although Estuary document is not changed.
https://docs.estuary.tech/api-content-add-ipfs
The response of original request now becomes
{
    "error": {
        "code": 500,
        "reason": "Internal Server Error",
        "details": "cid too short"
    }
}